### PR TITLE
fix: create user deploy

### DIFF
--- a/sirene_as_api.yml
+++ b/sirene_as_api.yml
@@ -15,6 +15,7 @@
 
   roles:
     - { role: python_install_raw, tags: ['python_raw'] }
+    - { role: deploy_user, tags: ['deploy_user'] }
     - { role: nginx, mina_deploy: true, tags: ['nginx'] }
     - { role: rails_app, tags: sirene_rails_app }
     - { role: ruby, tags: ['ruby', 'rbenv'] }


### PR DESCRIPTION
Nous obtenons une erreur sur le répertoire `/var/www` si la ligne n'est pas présente puisque l'utilisateur `deploy` est appelé entre autre dans ce fichier : [roles/rails_app/tasks/main.yml](https://github.com/etalab/sirene_as_api_ansible/blob/master/roles/rails_app/tasks/main.yml)